### PR TITLE
verified v13

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,6 @@
+1.0.9
+* Verified compatibility with Foundry v13
+
 1.0.8
 * Trying again with the perms
 

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
   "id": "pfs-provisions",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "title": "Pathfinder Provisions",
   "description": "Contains a convenient drag-and-drop list of items eligible for use as Pathfinder Provisions for PF2e Organized Play.",
   "authors": [
@@ -15,7 +15,7 @@
   "download": "https://github.com/benyar/pfs-provisions/zipball/master/",
   "compatibility": {
     "minimum": "11",
-    "verified": "12"
+    "verified": "13"
   },
   "media": [
     {


### PR DESCRIPTION
- no changes needed for v13. this is a simple increase in version number to change `verified` attribute. 